### PR TITLE
fix: remove pinia auto import settings

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,13 +18,6 @@ export default defineNuxtConfig({
       },
     ],
   ],
-  pinia: {
-    autoImports: [
-      // automatically imports `defineStore`
-      'defineStore',
-      ['defineStore', 'definePiniaStore'],
-    ],
-  },
   runtimeConfig: {
     // Public keys that are exposed to the client
     public: {


### PR DESCRIPTION
### Overview
- remove pinia auto import setting because Nuxt already implement auto import

### Evidence

title: fix remove pinia auto import
project: J-Site
participants: @Ibwedagama @yoslie @doohanas @maulanayuseph 
