### PR TITLE
feat: improve data fetching on builder create page

### DIFF
--- a/components/Page/BuilderContent.vue
+++ b/components/Page/BuilderContent.vue
@@ -4,7 +4,7 @@
     <template v-if="props.loading">
       <div class="flex flex-col gap-y-[27px]">
         <section
-          v-for="index in 8"
+          v-for="index in 7"
           :key="`builder-skeleton-${index}`"
           class="h-[406px] w-full animate-pulse rounded-lg bg-gray-200"
         />

--- a/components/Page/BuilderContent.vue
+++ b/components/Page/BuilderContent.vue
@@ -1,22 +1,44 @@
 <template>
   <main class="grid h-full w-full px-4">
-    <section v-for="(section, index) in sections" :key="index">
-      <div class="my-1.5 flex h-[17px] w-full items-center">
-        <span class="h-[1px] flex-1 bg-[#DEDEDE]" />
-        <p
-          v-if="index < 2"
-          class="flex-none px-1 font-inter text-xs font-medium text-[#989898]"
-        >
-          {{ index === 0 ? 'Hero Section' : 'Konten Section' }}
-        </p>
-        <span class="h-[1px] flex-1 bg-[#DEDEDE]" />
+    <!-- Loading Skeleton -->
+    <template v-if="props.loading">
+      <div class="flex flex-col gap-y-[27px]">
+        <section
+          v-for="index in 8"
+          :key="`builder-skeleton-${index}`"
+          class="h-[406px] w-full animate-pulse rounded-lg bg-gray-200"
+        />
       </div>
-      <PageBuilderWidgetContainer :section="section" :section-index="index" />
-    </section>
+    </template>
+    <template v-else>
+      <section
+        v-for="(section, index) in sections"
+        :key="`builder-section-${index}`"
+      >
+        <div class="my-1.5 flex h-[17px] w-full items-center">
+          <span class="h-[1px] flex-1 bg-[#DEDEDE]" />
+          <p
+            v-if="index < 2"
+            class="flex-none px-1 font-inter text-xs font-medium text-[#989898]"
+          >
+            {{ index === 0 ? 'Hero Section' : 'Konten Section' }}
+          </p>
+          <span class="h-[1px] flex-1 bg-[#DEDEDE]" />
+        </div>
+        <PageBuilderWidgetContainer :section="section" :section-index="index" />
+      </section>
+    </template>
   </main>
 </template>
 
 <script setup lang="ts">
+  const props = defineProps({
+    loading: {
+      type: Boolean,
+      default: true,
+    },
+  })
+
   const pageStore = usePageStore()
 
   const sections = computed(() => {

--- a/components/Page/BuilderHeader.vue
+++ b/components/Page/BuilderHeader.vue
@@ -37,7 +37,13 @@
           class="fill-green-500 text-base text-green-500"
           aria-hidden="true"
         />
+        <!-- Loading Skeleton -->
         <span
+          v-if="props.loading"
+          class="h-[26px] w-[150px] animate-pulse rounded-lg bg-gray-200"
+        />
+        <span
+          v-else
           class="rounded-lg bg-[#F7F7F9] px-2 py-1.5 text-xs text-[#788896]"
         >
           {{ domain }}
@@ -89,6 +95,13 @@
 </template>
 
 <script setup lang="ts">
+  const props = defineProps({
+    loading: {
+      type: Boolean,
+      default: true,
+    },
+  })
+
   const pageStore = usePageStore()
 
   const domain = computed(() => {

--- a/pages/halaman/buat.vue
+++ b/pages/halaman/buat.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="h-full w-full bg-[#F3F4F8] pb-24">
-    <PageBuilderHeader />
+    <PageBuilderHeader :loading="fetchSettingStatus === 'pending'" />
     <div class="flex h-full w-full justify-between gap-4 px-1 py-4">
-      <PageBuilderContent />
+      <PageBuilderContent :loading="fetchTemplateStatus === 'pending'" />
       <PageBuilderAside />
     </div>
   </div>
@@ -176,35 +176,27 @@
   pageStore.setPageTitle(route.query.title?.toString() ?? '')
   pageStore.setPageTemplate(route.query.templateId?.toString() ?? '')
 
-  const { data: settingData, error: fetchSettingError } =
+  const { data: setting, status: fetchSettingStatus } =
     await $jSiteApi.settings.getSettingsById(
       siteStore?.siteId ?? '',
       undefined, // no query params for this request
-      { server: false },
+      { server: false, lazy: true },
     )
 
-  if (fetchSettingError.value) {
-    console.error(toRaw(fetchSettingError.value))
-  } else {
-    pageStore.setPageDomain(toRaw(settingData.value?.data?.domain || ''))
-  }
+  watch(setting, () => {
+    pageStore.setPageDomain(toRaw(setting.value?.data?.domain || ''))
+  })
 
-  const { data: templateData, error: fetchTemplateError } =
+  const { data: template, status: fetchTemplateStatus } =
     await $jSiteApi.templates.getTemplateById(
       pageStore.builderConfig?.templateId ?? '',
       undefined, // no query params for this request
-      {
-        server: false,
-      },
+      { server: false, lazy: true },
     )
 
-  if (fetchTemplateError.value) {
-    console.error(toRaw(fetchTemplateError.value))
-  } else {
-    pageStore.setBuilderSections(
-      toRaw(templateData.value?.data?.sections || []),
-    )
-  }
+  watch(template, () => {
+    pageStore.setBuilderSections(toRaw(template.value?.data?.sections || []))
+  })
 
   // const backToPage = () => {
   //   state.modal.status = MODAL_STATE.CANCEL_CONFIRMATION

--- a/pages/halaman/buat.vue
+++ b/pages/halaman/buat.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="h-full w-full bg-[#F3F4F8] pb-24">
-    <PageBuilderHeader :loading="fetchSettingStatus === 'pending'" />
+    <PageBuilderHeader :loading="fetchSettingLoading" />
     <div class="flex h-full w-full justify-between gap-4 px-1 py-4">
-      <PageBuilderContent :loading="fetchTemplateStatus === 'pending'" />
+      <PageBuilderContent :loading="fetchTemplateLoading" />
       <PageBuilderAside />
     </div>
   </div>
@@ -176,7 +176,7 @@
   pageStore.setPageTitle(route.query.title?.toString() ?? '')
   pageStore.setPageTemplate(route.query.templateId?.toString() ?? '')
 
-  const { data: setting, status: fetchSettingStatus } =
+  const { data: setting, pending: fetchSettingLoading } =
     await $jSiteApi.settings.getSettingsById(
       siteStore?.siteId ?? '',
       undefined, // no query params for this request
@@ -187,7 +187,7 @@
     pageStore.setPageDomain(toRaw(setting.value?.data?.domain || ''))
   })
 
-  const { data: template, status: fetchTemplateStatus } =
+  const { data: template, pending: fetchTemplateLoading } =
     await $jSiteApi.templates.getTemplateById(
       pageStore.builderConfig?.templateId ?? '',
       undefined, // no query params for this request


### PR DESCRIPTION
### Overview
Nuxt has built-in `useAsyncData` composable to fetch data on either client-side or server-side and it is also used on the Repository Pattern. The issues with this approach when used on the client side are:
1. All async operations must be resolved before doing navigation. This can cause a bad user experience as the user would think the app was not responding immediately
2. We have to adjust the behavior of useAsyncData using options `{ server: false }` to fetch data on the client-side

IMHO the 2nd issue isn't a big deal as we can easily provide `useAsyncData` options inside the Repository Pattern. however, the 1st issue really needs some adjustment.

Look at this example video:

https://github.com/jabardigitalservice/j-site-builder/assets/33661143/61d2afeb-6904-47ad-bd2e-1a31ac3b368b

when the user creates a new page, the navigation does not respond immediately. this causes confusion for the user and will get worse if the connection speed is slow.

### Proposed Solutions
To address this issue, we can change the behavior of useAsyncData using options `{ server: false, lazy: true }`. 
1. `{ server: false }` will make sure the fetching only executed on the client-side
2. `{ lazy: true }` will prevent the navigation block and fetch the data after navigation is complete
3. or we can use useLazyAsyncData. it's the same as using useAsyncData with option `{ lazy: true }`



however, with this approach, we have to add a loading skeleton to improve user experience, as the user will have to wait until data fetching is complete. 

> Under the hood, lazy: false uses <Suspense> to block the loading of the route before the data has been fetched. Consider using lazy: true and implementing a loading state instead for a snappier user experience.
ref: https://nuxt.com/docs/api/composables/use-async-data

the other drawback of this approach is when using `{ server: false, lazy: true }` options, the data will not be available immediately even if we use `async await`, so we have to add a watcher (`watch`) function to change the state after fetching complete. Here are the example from official Nuxt Docs:

```vue
<script setup lang="ts">
/* Navigation will occur before fetching is complete.
  Handle pending and error states directly within your component's template
*/
const { pending, data: count } = await useLazyAsyncData('count', () => $fetch('/api/count'))

watch(count, (newCount) => {
  // Because count might start out null, you won't have access
  // to its contents immediately, but you can watch it.
})
</script>

<template>
  <div>
    {{ pending ? 'Loading' : count }}
  </div>
</template>

```

ref: https://nuxt.com/docs/api/composables/use-lazy-async-data

### Result
After implementing useAsyncData with options `{ server: false, lazy: true }` and adding UI Skeleton, we can provide a snappier user experience

https://github.com/jabardigitalservice/j-site-builder/assets/33661143/1dadc8ef-5ddc-427f-b714-7a602f78da2c


### Changes

- add useAsyncData options to functions that handle fetching `setting` and `template`
- add UI Skeleton on `PageBuilderHeader` and `PageBuilderContent`


### Related

- [S5A5 - Membuat Add Page (Costumize Template)](https://app.clickup.com/t/9003239225/CES-1307)

### Evidence

title: feat improve data fetching on builder create page
project: J-Site
participants: @Ibwedagama @marsellavaleria19 @yoslie @doohanas 
