### PR TITLE
refactor (agenda): improve data binding on cancel and close modal

### DIFF
--- a/stores/page.ts
+++ b/stores/page.ts
@@ -13,7 +13,18 @@ export const usePageStore = defineStore('page', {
       sections: [] as ITemplateSection[],
     },
   }),
-  getters: {},
+  getters: {
+    getWidgetPayload(state) {
+      return ({
+        sectionIndex,
+        widgetIndex,
+      }: {
+        sectionIndex: number
+        widgetIndex: number
+      }) =>
+        state.builderConfig.sections[sectionIndex].widgets[widgetIndex].payload
+    },
+  },
   actions: {
     setPageType(value: string) {
       this.builderConfig.type = value


### PR DESCRIPTION
### Overview
- sync form data with `pageStore` when the user cancels data change

### Changes

- create a `getWidgetPayload` getter on `pageStore`
- refactor code structure
- improve data binding when user cancels data changes

### Preview

https://github.com/jabardigitalservice/j-site-builder/assets/33661143/9454b4fd-cdf6-4069-a2b6-ec76f22fe1b4



### Related
[S7A4 - Membuat Widget Agenda](https://app.clickup.com/t/9003239225/CES-1461)

### Evidence

title: refactor agenda widget data binding 
project: J-Site
participants: @Ibwedagama @marsellavaleria19 @yoslie @doohanas 
