### PR TITLE
fix: fix single filter categories in posting page

### DIFF
--- a/pages/posting/index.vue
+++ b/pages/posting/index.vue
@@ -282,9 +282,10 @@
 
   async function fetchDataPost() {
     loadingData.value = true
+    const { categories, ...rest } = params
     const { data: responseData } = await $jSiteApi.post.getPostList(
       siteStore.siteId ?? '',
-      { query: params },
+      { query: { 'categories[]': [...categories], ...rest } },
       { server: false },
     )
 

--- a/pages/posting/index.vue
+++ b/pages/posting/index.vue
@@ -275,20 +275,10 @@
 
       params.status = findMenu?.status || ''
 
-      clearParams()
       fetchDataPost()
     },
     { immediate: true },
   )
-
-  function clearParams() {
-    params.page = 1
-    params.q = ''
-    params.limit = 10
-    params.start_date = ''
-    params.end_date = ''
-    params.categories = []
-  }
 
   async function fetchDataPost() {
     loadingData.value = true
@@ -307,6 +297,8 @@
         ...item,
         index: index + Number(metaData?.from),
       }))
+    } else {
+      post.data = postData
     }
 
     post.meta = metaData


### PR DESCRIPTION
### Related

- [S4A3 - Membuat Filter Post](https://app.clickup.com/t/9003239225/CES-2933)

### Changes

- Fix behavior search and filter for each change tab
- Fix single filter categories in posting page

### Issue

- For the record: `ofect` library have an issue when we send `params` single string of Array will force change into single string.
See the issue here: https://github.com/unjs/ofetch/issues/119
How I fix it: https://github.com/jabardigitalservice/j-site-builder/commit/2bd9db77264cc8cc0e99c20e9cf0edf59f323769

### Preview


### Evidence

title: fix: fix single filter categories in posting page
project: J-Site
participants: @doohanas