### PR TITLE
feat: posting form save as draft

### DIFF
--- a/pages/posting/buat.vue
+++ b/pages/posting/buat.vue
@@ -2,7 +2,7 @@
   <PostForm @submit-form="openPublishConfirmation">
     <template #header="{ valid }">
       <nav class="mb-[14px] flex items-center justify-between py-[14px]">
-        <UButton variant="outline" @click="goBack">
+        <UButton variant="outline" @click="$router.back">
           <template #leading>
             <NuxtIcon
               name="common/arrow-left"
@@ -235,9 +235,5 @@
 
       console.error(error)
     }
-  }
-
-  function goBack() {
-    // TODO: handle router go back
   }
 </script>

--- a/pages/posting/buat.vue
+++ b/pages/posting/buat.vue
@@ -52,11 +52,65 @@
       <UButton variant="outline" type="button" @click="closeModal">
         Batal
       </UButton>
-      <UButton v-show="modal.status === 'SAVE_AS_DRAFT'" type="button">
+      <UButton
+        v-show="modal.status === 'SAVE_AS_DRAFT'"
+        type="button"
+        @click="saveAsDraft"
+      >
         Ya, simpan ke draf
       </UButton>
       <UButton v-show="modal.status === 'PUBLISH'" type="button">
         Ya, simpan post
+      </UButton>
+    </template>
+  </BaseModal>
+
+  <!-- Submit Progress -->
+  <ProgressModal
+    :open="modal.status === 'LOADING'"
+    :value="modal.progress ?? 0"
+    :title="modal.title"
+    :message="modal.message"
+  />
+
+  <!-- Success/Error Confirmation -->
+  <BaseModal
+    :open="modal.status === 'SUCCESS' || modal.status === 'ERROR'"
+    :header="modal.title"
+    button-position="center"
+  >
+    <p class="mb-4 flex items-center">
+      <NuxtIcon
+        v-show="modal.status === 'SUCCESS'"
+        name="common/check-circle"
+        class="mr-3 inline-block text-xl text-green-500"
+        aria-hidden="true"
+      />
+      <NuxtIcon
+        v-show="modal.status === 'ERROR'"
+        name="common/warning-triangle"
+        class="mr-3 inline-block text-xl text-yellow-500"
+        aria-hidden="true"
+      />
+      <span class="text-md font-lato leading-6 text-gray-700">
+        {{ modal.message }}
+      </span>
+    </p>
+    <template #footer>
+      <UButton
+        v-show="modal.status === 'ERROR'"
+        type="button"
+        @click="closeModal"
+      >
+        Saya Mengerti
+      </UButton>
+
+      <UButton
+        v-show="modal.status === 'SUCCESS'"
+        type="button"
+        @click="navigateTo('/posting')"
+      >
+        Saya Mengerti
       </UButton>
     </template>
   </BaseModal>
@@ -67,23 +121,29 @@
     title: 'Posting',
   })
 
-  type IModalState = 'NONE' | 'SAVE_AS_DRAFT' | 'PUBLISH'
+  const postStore = usePostStore()
+  const siteStore = useSiteStore()
+  const { $jSiteApi } = useNuxtApp()
 
   interface IModalConfirmation {
-    status: IModalState
+    status:
+      | 'NONE'
+      | 'SAVE_AS_DRAFT'
+      | 'PUBLISH'
+      | 'LOADING'
+      | 'SUCCESS'
+      | 'ERROR'
     title: string
     message: string
+    progress?: number
   }
 
   const modal = reactive<IModalConfirmation>({
     status: 'NONE',
     title: '',
     message: '',
+    progress: 0,
   })
-
-  function goBack() {
-    // TODO: handle router go back
-  }
 
   function setModal({ status, title, message }: IModalConfirmation) {
     modal.status = status
@@ -118,5 +178,66 @@
   function resetModal() {
     modal.title = ''
     modal.message = ''
+    modal.progress = 0
+  }
+
+  function setSubmitProgress(value: number) {
+    modal.progress = value
+  }
+
+  async function saveAsDraft() {
+    const body = postStore.generateFormData({ status: 'DRAFT' })
+
+    if (!body.title) {
+      setModal({
+        status: 'ERROR',
+        title: 'Terjadi Kesalahan',
+        message: 'Silakan memasukkan judul post terlebih dahulu',
+      })
+
+      return
+    }
+
+    setSubmitProgress(50)
+    setModal({
+      status: 'LOADING',
+      title: 'Simpan ke Draf',
+      message: 'Mohon tunggu, penyimpanan post ke Draf sedang diproses.',
+    })
+
+    const { status, error } = await $jSiteApi.post.createPost(
+      siteStore.siteId ?? '',
+      body,
+      { server: false },
+    )
+
+    if (status.value === 'success') {
+      setSubmitProgress(100)
+
+      setTimeout(() => {
+        setModal({
+          status: 'SUCCESS',
+          title: 'Berhasil Simpan ke Draf',
+          message: 'Post yang Anda submit berhasil disimpan ke Draf',
+        })
+      }, 500)
+    }
+
+    if (status.value === 'error') {
+      setTimeout(() => {
+        setModal({
+          status: 'ERROR',
+          title: 'Gagal Simpan ke Draf',
+          message:
+            'Mohon maaf, post yang Anda submit gagal disimpan. Mohon coba beberapa saat lagi.',
+        })
+      }, 500)
+
+      console.error(error)
+    }
+  }
+
+  function goBack() {
+    // TODO: handle router go back
   }
 </script>

--- a/pages/posting/buat.vue
+++ b/pages/posting/buat.vue
@@ -1,5 +1,5 @@
 <template>
-  <PostForm @submit-form="handlePublish">
+  <PostForm @submit-form="openPublishConfirmation">
     <template #header="{ valid }">
       <nav class="mb-[14px] flex items-center justify-between py-[14px]">
         <UButton variant="outline" @click="goBack">
@@ -14,7 +14,11 @@
         </UButton>
 
         <div class="flex gap-x-[14px]">
-          <UButton variant="outline" type="button" @click="handleSaveAsDraft">
+          <UButton
+            variant="outline"
+            type="button"
+            @click="openSaveAsDraftConfirmation"
+          >
             <template #leading>
               <NuxtIcon
                 name="common/folder"
@@ -34,6 +38,28 @@
       </nav>
     </template>
   </PostForm>
+
+  <!-- Confirmation Modal for Save as Draft and Publish -->
+  <BaseModal
+    :open="modal.status === 'SAVE_AS_DRAFT' || modal.status === 'PUBLISH'"
+    :header="modal.title"
+    button-position="right"
+  >
+    <p class="text-md mb-4 font-lato leading-6 text-gray-700">
+      {{ modal.message }}
+    </p>
+    <template #footer>
+      <UButton variant="outline" type="button" @click="closeModal">
+        Batal
+      </UButton>
+      <UButton v-show="modal.status === 'SAVE_AS_DRAFT'" type="button">
+        Ya, simpan ke draf
+      </UButton>
+      <UButton v-show="modal.status === 'PUBLISH'" type="button">
+        Ya, simpan post
+      </UButton>
+    </template>
+  </BaseModal>
 </template>
 
 <script setup lang="ts">
@@ -41,15 +67,56 @@
     title: 'Posting',
   })
 
+  type IModalState = 'NONE' | 'SAVE_AS_DRAFT' | 'PUBLISH'
+
+  interface IModalConfirmation {
+    status: IModalState
+    title: string
+    message: string
+  }
+
+  const modal = reactive<IModalConfirmation>({
+    status: 'NONE',
+    title: '',
+    message: '',
+  })
+
   function goBack() {
     // TODO: handle router go back
   }
 
-  function handlePublish() {
-    // TODO: add save as published handler
+  function setModal({ status, title, message }: IModalConfirmation) {
+    modal.status = status
+    modal.title = title
+    modal.message = message
   }
 
-  function handleSaveAsDraft() {
-    // TODO: add save as draft handler
+  function openSaveAsDraftConfirmation() {
+    setModal({
+      status: 'SAVE_AS_DRAFT',
+      title: 'Simpan ke Draf',
+      message: 'Apakah Anda ingin menyimpan Post ini ke draf?',
+    })
+  }
+
+  function openPublishConfirmation() {
+    setModal({
+      status: 'PUBLISH',
+      title: 'Simpan Post',
+      message: 'Apakah Anda ingin menyimpan Post ini?',
+    })
+  }
+
+  function closeModal() {
+    modal.status = 'NONE'
+
+    setTimeout(() => {
+      resetModal()
+    }, 300)
+  }
+
+  function resetModal() {
+    modal.title = ''
+    modal.message = ''
   }
 </script>

--- a/repository/j-site/modules/post.ts
+++ b/repository/j-site/modules/post.ts
@@ -2,7 +2,7 @@ import { AsyncDataOptions } from '#app'
 import { FetchOptions } from 'ofetch'
 
 import FetchFactory from '../../factory'
-import { IPostsResponse } from '../types/post'
+import { IPostsResponse, IPostBodyRequest } from '../types/post'
 
 class PostModules extends FetchFactory {
   private RESOURCE = '/v1/posts'
@@ -18,6 +18,20 @@ class PostModules extends FetchFactory {
         `${this.RESOURCE}/${id}`,
         undefined, // body
         fetchOptions,
+      )
+    }, options)
+  }
+
+  async createPost(
+    idSetting: string,
+    body: IPostBodyRequest,
+    options?: AsyncDataOptions<IPostsResponse>,
+  ) {
+    return useAsyncData(() => {
+      return this.call<IPostsResponse>(
+        'POST',
+        `${this.RESOURCE}/${idSetting}`,
+        body,
       )
     }, options)
   }

--- a/repository/j-site/types/post.ts
+++ b/repository/j-site/types/post.ts
@@ -25,3 +25,14 @@ export interface IPostsResponse {
   data?: IPostData[]
   meta?: IMetaData
 }
+
+export type IFormStatus = 'DRAFT' | 'PUBLISHED'
+
+export interface IPostBodyRequest {
+  content: string
+  author: string
+  category: string | null
+  image: string
+  tags: string[]
+  status: IFormStatus | null
+}

--- a/stores/post.ts
+++ b/stores/post.ts
@@ -1,3 +1,5 @@
+import { IFormStatus } from '~/repository/j-site/types/post'
+
 type IForm = {
   title: string
   image: {
@@ -11,8 +13,6 @@ type IForm = {
   tags: null | string[]
   status: null | IFormStatus
 }
-
-type IFormStatus = 'DRAFT' | 'PUBLISHED'
 
 export const usePostStore = defineStore('post', {
   state: () => ({
@@ -62,6 +62,22 @@ export const usePostStore = defineStore('post', {
     removeTag(tag: string) {
       if (this.form.tags?.includes(tag)) {
         this.form.tags = this.form.tags?.filter((item) => item !== tag)
+      }
+    },
+    setStatus(status: IFormStatus) {
+      this.form.status = status
+    },
+    generateFormData({ status }: { status: IFormStatus }) {
+      this.setStatus(status)
+
+      return {
+        title: this.form.title,
+        image: this.form.image.uri,
+        content: this.form.content,
+        author: this.form.author,
+        category: this.form.category ? this.form.category : null,
+        tags: this.form.tags ? [...this.form.tags] : [],
+        status: this.form.status,
       }
     },
   },


### PR DESCRIPTION
### Changes
- add `createPost` method on post module
- add confirmation modals, progress modal and success/error modals
- handle save as draft

### Preview

https://github.com/jabardigitalservice/j-site-builder/assets/33661143/026d759f-9fb3-4c63-9ed4-cddabad28925



### Related
[S4A5 - Mengimplementasikan Status Post](https://app.clickup.com/t/9003239225/CES-2956)

### Evidence

title: feat posting form save as draft
project: J-Site
participants: @Ibwedagama @marsellavaleria19 @yoslie @doohanas 
