### PR TITLE
refactor: page save as draft

### DIFF
--- a/pages/halaman/buat.vue
+++ b/pages/halaman/buat.vue
@@ -209,6 +209,7 @@
 
   watch(template, () => {
     pageStore.setBuilderSections(toRaw(template.value?.data?.sections || []))
+    pageStore.setPageCategory(toRaw(template.value?.data?.category || ''))
   })
 
   const backToPage = () => {

--- a/pages/halaman/buat.vue
+++ b/pages/halaman/buat.vue
@@ -257,6 +257,7 @@
         title: pageStore.builderConfig?.title ?? '',
         status: 'DRAFT',
         sections: toRaw(pageStore.builderConfig?.sections),
+        category: pageStore.builderConfig?.category ?? '',
       },
       { server: false },
     )

--- a/repository/j-site/types/page.ts
+++ b/repository/j-site/types/page.ts
@@ -2,6 +2,7 @@ export interface IPageData {
   title: string
   status: string
   sections: unknown[]
+  category: string
 }
 
 export interface IPageResponse {

--- a/repository/j-site/types/template.ts
+++ b/repository/j-site/types/template.ts
@@ -28,6 +28,7 @@ export interface ITemplateData {
   sections: ITemplateSection[]
   created_at: string
   updated_at: string
+  category: string
 }
 
 export type ITemplatesResponse = {

--- a/stores/page.ts
+++ b/stores/page.ts
@@ -11,6 +11,7 @@ export const usePageStore = defineStore('page', {
       domain: null as null | string,
       lastUpdate: null as null | string,
       sections: [] as ITemplateSection[],
+      category: null as null | string,
     },
   }),
   getters: {
@@ -28,6 +29,9 @@ export const usePageStore = defineStore('page', {
   actions: {
     setPageType(value: string) {
       this.builderConfig.type = value
+    },
+    setPageCategory(value: string) {
+      this.builderConfig.category = value
     },
     setPageTemplate(value: string) {
       this.builderConfig.templateId = value


### PR DESCRIPTION
### Overview

- as required by BE team, when user save as draft a page the application should be sending `category` property to request body

### Changes
- add `category` type definition on ITemplateData
- store `category` data to pageStore
- send `category` data to request body on save as draft


### Evidence

title: refactor page save as draft
project: J-Site
participants: @Ibwedagama @marsellavaleria19 @agunghide @rayfajars @yoslie @doohanas 
